### PR TITLE
Fixed not specified install dir in install_subdir() function

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -414,7 +414,7 @@ static std::string ProcessTemplate(std::string_view templateStr, const json& bui
 			return "";
 		std::string str;
 		for(const auto& value : it.value())
-			str.append(std::format("install_subdir('{}')\n", value.template get<std::string>()));
+			str.append(std::format("install_subdir('{}', install_dir : get_option('includedir'))\n", value.template get<std::string>()));
 		return str;
 	});
 	SubstitutePlaceholder(str, "$$build_targets$$", [&buildMasterJson]() -> std::string


### PR DESCRIPTION
 - This fixes the meson.build script when install_header_dirs is present in build_master.json