### PR TITLE
path fix: Use .string() instead of .native() for std::filesystem::path

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -34,7 +34,7 @@ static constexpr std::string_view gMesonBuildScriptFilePath = "meson.build";
 static std::string GetPathStrRelativeToDir(std::string_view directoryBase, std::string_view relativePath)
 {
 	auto buildMasterJsonFilePath = std::filesystem::path(directoryBase) / std::filesystem::path(relativePath);
-	return buildMasterJsonFilePath.native();
+	return buildMasterJsonFilePath.string();
 }
 
 // Use this function whenever you meant to get gBuildMasterJsonFilePath.


### PR DESCRIPTION
The `std::filesystem::path::native()` returns wide char string on Windows as windows uses Unicode by default, while it returns the regular string on Linux. Since we used `native()`, it caused build failure on windows.

Use `std::filesystem::path::string()` as it returns the single byte char string across different platforms.