### PR TITLE
Generate meson.build code for variables (with meta info) and their references

### DIFF
--- a/meson.build.template
+++ b/meson.build.template
@@ -48,6 +48,9 @@ project($$project_name$$, 'c', 'cpp',
   ]
 )
 
+# Variables
+$$vars$$
+
 # Release Build Defines
 release_defines = [
 $$release_defines$$


### PR DESCRIPTION
The implementation recognizes and generates appropriate meson code for the following json code:
```json
    "vars" :
    {
        "cuda_path" : "get_variable('CUDA_PATH', '')",
        "cuda_includes" : "cuda_path + '/include'",
        "cuda_libs_path" : "cuda_path + '/lib/x64'",
        "vulkan_sdk_path" : "get_variable('VK_SDK_PATH', '')",
        "vulkan_libs_path" : "vulkan_sdk_path + '/Lib/'",
        "gtk3_cflags" : "run_command('pkg-config', 'gtk+-3.0', '--cflags').stdout().split(' ')",
        "gtk3_libs" : "run_command('pkg-config', 'gtk+-3.0', '--libs').stdout().split(' ')",
        "gui_sources" : [
            "source/GUI/AddUI.cpp",
            "source/GUI/MachineUI.cpp",
            "source/GUI/MainUI.cpp"
        ]
    },
```
And Usage:
```json
            "windows_link_args" : [
                "link_dir: './external-dependencies/x264'", "-lx264", "-lx264"
            ]
```
```json
            "windows_link_args" : [
                "link_dir: $cuda_libs_path", "-l:cuda.lib",
                "link_dir: './external-dependencies/NvidiaCodec/'", "-l:nvcuvid.lib",
                "link_dir: $vulkan_libs_path", "-lvulkan-1"                
            ]
```
```json
            "sources" : [
                "source/third_party/NvDecoder.cpp",
                "source/Decoder.cpp",
                "source/main.client.cpp",
                "source/Window.cpp",
                "source/Win32/Win32DrawSurface.cpp",
                "source/Win32/Win32RawInput.cpp",
                "source/Win32/Win32Window.cpp",
                "source/HDMIDecoderNetStream.cpp",
                "source/KMNetStream.cpp",
                "source/HIDUsageID.cpp",
                "source/RDPSession.cpp",
                "source/PresentEngine.cpp",
                "$gui_sources"
            ]
```