### PR TITLE
Fixed defines not generated in meson.build while it exists in build_m…

### DIFF
--- a/meson.build.template
+++ b/meson.build.template
@@ -51,6 +51,11 @@ project($$project_name$$, 'c', 'cpp',
 # Variables
 $$vars$$
 
+# Defines
+defines_bm_internal__ = [
+$$defines$$
+]
+
 # Release Build Defines
 release_defines_bm_internal__ = [
 $$release_defines$$
@@ -110,7 +115,7 @@ add_project_link_arguments('-m64', link_args_bm_internal__, language : 'c')
 add_project_link_arguments('-m64', link_args_bm_internal__, language : 'cpp')
 
 # Build type specific defines
-build_mode_defines_bm_internal__ = []
+build_mode_defines_bm_internal__ = defines_bm_internal__
 if get_option('buildtype') == 'release'
   add_project_arguments(release_defines_bm_internal__, language : 'c')
   add_project_arguments(release_defines_bm_internal__, language : 'cpp')

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -449,6 +449,7 @@ static constexpr std::pair<std::string_view, std::string_view> gPlaceHolderToJso
 {
 	{ "$$release_defines$$", "release_defines" },
 	{ "$$debug_defines$$", "debug_defines" },
+	{ "$$defines$$", "defines" },
 	{ "$$sources$$", "sources" },
 	{ "$$include_dirs$$", "include_dirs" },
 	{ "$$windows_link_args$$", "windows_link_args" },


### PR DESCRIPTION
…aster.json

Affected `build_master.json`:
```cpp
{
  ....
    "defines" : [
        "-DUSE_PERSISTENT_SETTINGS",
        "-DUSE_VULKAN_PRESENTATION",
        "-DUSE_VULKAN_FOR_COLOR_SPACE_CONVERSION",
        "-DUSE_DIRECT_FRAME_DATA_COPY"
    ],
  ....
}
```
**Before this Fix**:
None of the defines made to `meson.build`
**After this Fix**:
All of the defines now make to `meson.build`