### PR TITLE
Bug Fix: Add comma after subdirs argument in the generated meson.build

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -373,6 +373,7 @@ static void ProcessTarget(const json& targetJson,
 			{
 				stream << "\tsubdirs: ";
 				ProcessStringList(targetJson, "subdirs", stream);
+				stream << ", ";
 			}
 			stream << std::format("\textra_cflags: {}{} + build_mode_defines_bm_internal__\n", name, suffixData.useDefines);
 			stream << ")\n";


### PR DESCRIPTION
This fixes the following error when building [PlayVk](https://github.com/ravi688/PlayVk):
../meson.build:201:1: ERROR: Expecting rparen got id.
        extra_cflags: playvk_headers_use_defines_bm_internal__ + build_mode_defines_bm_internal__
 ^