### PR TITLE
Implemented support for install_headers

### DIFF
--- a/meson.build.template
+++ b/meson.build.template
@@ -167,3 +167,4 @@ $$build_targets$$
 #--------------------------------Header Intallation----------------------------------
 # Header installation
 $$install_subdirs$$
+$$install_headers$$

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -511,6 +511,23 @@ static std::string ProcessTemplate(std::string_view templateStr, const json& bui
 			str.append(std::format("install_subdir('{}', install_dir : get_option('includedir'))\n", value.template get<std::string>()));
 		return str;
 	});
+	SubstitutePlaceholder(str, "$$install_headers$$", [&buildMasterJson]() -> std::string
+	{
+		auto it = buildMasterJson.find("install_headers");
+		if(it == buildMasterJson.end())
+			return "";
+		std::ostringstream stream;
+		for(const auto& value : it.value())
+		{
+			stream << "install_headers(";
+			ProcessStringList(value, "files", stream, "\n");
+			auto it = value.find("subdir");
+			if(it != value.end())
+				stream << ", subdir: " << single_quoted_str((*it).template get<std::string>());
+			stream << ")\n";
+		}
+		return stream.str();
+	});
 	SubstitutePlaceholder(str, "$$build_targets$$", [&buildMasterJson]() -> std::string
 	{
 		ProjectMetaInfo projMetaInfo;


### PR DESCRIPTION
**Example build master json file**:
```json
{
    "project_name": "TemplateSystem",
    "canonical_name": "tempsys",
    "install_headers" : [
        {
            "subdir" : "my_sub_dir",
            "files" : [ "include/template_system.h" ]
        }
    ],
    "include_dirs": "include",
    "targets": [
        {
            "name": "tempsys",
            "is_header_only_library" : true
        }
    ]
}
```

Here `"subdir"` is optional, i.e. if not specified then the header files are installed in default `<prefix>/include` dir.