### PR TITLE
Renamed build_mode_defines to project_build_mode_defines to avoid confusion

### DIFF
--- a/meson.build.template
+++ b/meson.build.template
@@ -115,15 +115,15 @@ add_project_link_arguments('-m64', link_args_bm_internal__, language : 'c')
 add_project_link_arguments('-m64', link_args_bm_internal__, language : 'cpp')
 
 # Build type specific defines
-build_mode_defines_bm_internal__ = defines_bm_internal__
+project_build_mode_defines_bm_internal__ = defines_bm_internal__
 if get_option('buildtype') == 'release'
   add_project_arguments(release_defines_bm_internal__, language : 'c')
   add_project_arguments(release_defines_bm_internal__, language : 'cpp')
-  build_mode_defines_bm_internal__ += release_defines_bm_internal__
+  project_build_mode_defines_bm_internal__ += release_defines_bm_internal__
 else
   add_project_arguments(debug_defines_bm_internal__, language : 'c')
   add_project_arguments(debug_defines_bm_internal__, language : 'cpp')
-  build_mode_defines_bm_internal__ += debug_defines_bm_internal__
+  project_build_mode_defines_bm_internal__ += debug_defines_bm_internal__
 endif
 
 # pkg-config package installation

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -339,13 +339,13 @@ static void ProcessTarget(const json& targetJson,
 		if(targetType != TargetType::Executable)
 		{
 			stream << ",\n\tinstall_dir: lib_install_dir_bm_internal__";
-			stream << std::format(",\n\tc_args: {}{}", name, suffixData.buildDefines);
-			stream << std::format(",\n\tcpp_args: {}{}", name, suffixData.buildDefines);
+			stream << std::format(",\n\tc_args: {}{} + project_build_mode_defines_bm_internal__", name, suffixData.buildDefines);
+			stream << std::format(",\n\tcpp_args: {}{} + project_build_mode_defines_bm_internal__", name, suffixData.buildDefines);
 		}
 		else
 		{
-			stream << std::format(",\n\tc_args: {}{}", name, suffixData.buildDefines);
-			stream << std::format(",\n\tcpp_args: {}{}", name, suffixData.buildDefines);
+			stream << std::format(",\n\tc_args: {}{} + project_build_mode_defines_bm_internal__", name, suffixData.buildDefines);
+			stream << std::format(",\n\tcpp_args: {}{} + project_build_mode_defines_bm_internal__", name, suffixData.buildDefines);
 		}
 		stream << std::format(", \n\tlink_args: {}{}[host_machine.system()]", name, suffixData.linkArgs);
 		stream << ",\n\tgnu_symbol_visibility: 'hidden'";
@@ -358,7 +358,7 @@ static void ProcessTarget(const json& targetJson,
 		if(targetType != TargetType::HeaderOnlyLibrary)
 			stream << "\tlink_with: " << name << ",\n";
 		stream << std::format("\tinclude_directories: [inc_bm_internal__, {}{}],\n", name, suffixData.includeDirs);
-		stream << std::format("\tcompile_args: {}{} + build_mode_defines_bm_internal__\n", name, suffixData.useDefines);
+		stream << std::format("\tcompile_args: {}{} + project_build_mode_defines_bm_internal__\n", name, suffixData.useDefines);
 		stream << ")\n";
 		if(isInstall)
 		{
@@ -375,7 +375,7 @@ static void ProcessTarget(const json& targetJson,
 				ProcessStringList(targetJson, "subdirs", stream);
 				stream << ", ";
 			}
-			stream << std::format("\textra_cflags: {}{} + build_mode_defines_bm_internal__\n", name, suffixData.useDefines);
+			stream << std::format("\textra_cflags: {}{} + project_build_mode_defines_bm_internal__\n", name, suffixData.useDefines);
 			stream << ")\n";
 		}
 	}


### PR DESCRIPTION
This fixes "defines" not appearing the compile args. 