### PR TITLE
bugfix: pre-config hook bash script must be run before meson command

### DIFF
--- a/ci-linux-setup.sh
+++ b/ci-linux-setup.sh
@@ -5,3 +5,4 @@ apt-get install -y build-essential
 apt-get install -y meson cmake
 apt-get install python3
 apt-get install python-is-python3
+apt-get install libspdlog-dev

--- a/ci-mingw-setup.sh
+++ b/ci-mingw-setup.sh
@@ -1,3 +1,4 @@
 pacman -Sy --noconfirm mingw-w64-x86_64-meson \
 	 mingw-w64-x86_64-python \
-	 mingw-w64-x86_64-cmake
+	 mingw-w64-x86_64-cmake \
+	 mingw-w64-x86_64-spdlog

--- a/meson.build
+++ b/meson.build
@@ -56,7 +56,7 @@ sources = files('source/main.cpp')
 # Whether to install executable?
 is_install_executable = true
 
-dependencies = [ dependency('cli11'), dependency('nlohmann_json'), dependency('reproc') ]
+dependencies = [ dependency('cli11'), dependency('nlohmann_json'), dependency('reproc'), dependency('spdlog') ]
 
 # ------------------------------ INTERNALS ---------------------------------------
 

--- a/meson.build.template
+++ b/meson.build.template
@@ -48,9 +48,6 @@ project($$project_name$$, 'c', 'cpp',
   ]
 )
 
-# Pre configure hook (shell script run)
-$$pre_config_hook$$
-
 # Variables
 $$vars$$
 


### PR DESCRIPTION
 - This fixes the case when the bash script installs some wrapdb packages in the meson runtime (context).
 - meson loads the subprojects' data early on, therefore any wrapdb package download won't have any effect until the next meson setup command run.
 - This change makes sure that the pre-config hook will be run before the meson command.