### PR TITLE
[Fix] [Windows] Corrected bash command path when executing proconfig scripts on Windows

### DIFF
--- a/include/build_master/misc.hpp
+++ b/include/build_master/misc.hpp
@@ -2,7 +2,13 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 std::string LoadTextFile(std::string_view filePath);
 std::string GetPathStrRelativeToDir(std::string_view directoryBase, std::string_view relativePath);
 std::string GetBuildMasterJsonFilePath(std::string_view directory);
+
+// Selects a single path out of multiple given paths as follows:
+// 1. If the compilation platform is Windows then it chooses paths containing mingw, if not found then it looks for msys
+// 2. If the compilation platform is other than Windows then it chooses the first path at index 0.
+std::string SelectPath(const std::vector<std::string>& paths);

--- a/source/invoke_meson.cpp
+++ b/source/invoke_meson.cpp
@@ -1,5 +1,6 @@
 #include <build_master/meson_build_gen.hpp>
 #include <build_master/pre_config_script.hpp>
+#include <build_master/misc.hpp> // for SelectPath()
 
 #include <iostream>
 #include <cstdlib>
@@ -22,24 +23,6 @@ static std::ostream& operator<<(std::ostream& stream, const std::vector<std::str
 	for(const auto& value : v)
 		stream << value << " ";
 	return stream;
-}
-
-static std::string SelectPath(const std::vector<std::string>& paths)
-{
-	#ifdef _WIN32
-		// First try mingw
-		for(const auto& path : paths)
-			if(path.find("mingw") != std::string::npos)
-				return path;
-		// Then fallback to msys
-		for(const auto& path : paths)
-			if(path.find("msys") != std::string::npos)
-				return path;
-		spdlog::error("Couldn't find mingw or msys equivalent executable path");
-		exit(EXIT_FAILURE);
-	#else
-		return paths[0];
-	#endif
 }
 
 // cmdName: name of the command (not the full path, just the name)

--- a/source/misc.cpp
+++ b/source/misc.cpp
@@ -3,6 +3,8 @@
 #include <iostream>
 #include <filesystem>
 
+#include <spdlog/spdlog.h>
+
 std::string LoadTextFile(std::string_view filePath)
 {
 	std::ifstream stream(filePath.data());
@@ -35,4 +37,22 @@ static constexpr std::string_view gBuildMasterJsonFilePath = "build_master.json"
 std::string GetBuildMasterJsonFilePath(std::string_view directory)
 {
 	return GetPathStrRelativeToDir(directory, gBuildMasterJsonFilePath);
+}
+
+std::string SelectPath(const std::vector<std::string>& paths)
+{
+	#ifdef _WIN32
+		// First try mingw
+		for(const auto& path : paths)
+			if(path.find("mingw") != std::string::npos)
+				return path;
+		// Then fallback to msys
+		for(const auto& path : paths)
+			if(path.find("msys") != std::string::npos)
+				return path;
+		spdlog::error("Couldn't find mingw or msys equivalent executable path");
+		exit(EXIT_FAILURE);
+	#else
+		return paths[0];
+	#endif
 }


### PR DESCRIPTION
**What changed?**:
1. Determine absolute path which belongs to mingw64 or msys on Windows.